### PR TITLE
More informative errors for assay() with names.

### DIFF
--- a/R/SummarizedExperiment-class.R
+++ b/R/SummarizedExperiment-class.R
@@ -239,7 +239,7 @@ setMethod("assay", c("SummarizedExperiment", "character"),
         stop(msg, "\n", conditionMessage(err))
     })
     if (is.null(res))
-        stop(msg, "\n'i' not in names(assays(<", class(x), ">))")
+        stop(msg, "\n'", i, "' not in names(assays(<", class(x), ">))")
     res
 })
 


### PR DESCRIPTION
... because the current error is pretty cryptic:

```
Error in assay(se0, "whee") : 
  'assay(<SummarizedExperiment>, i="character", ...)' invalid subscript 'i'
'i' not in names(assays(<SummarizedExperiment>))
```

Which is fine for direct use of `assay()`, but it becomes harder to trace if people are using functions that call `assay()`, in which case there is often some confusion about the origin of the error. I have changed it so that we get instead:

```
Error in assay(se0, "whee") : 
  'assay(<SummarizedExperiment>, i="character", ...)' invalid subscript 'i'
'whee' not in names(assays(<SummarizedExperiment>))
```

... which should be more helpful.