### PR TITLE
Fix broken link to SummarizedExperiment doc

### DIFF
--- a/man/RangedSummarizedExperiment-class.Rd
+++ b/man/RangedSummarizedExperiment-class.Rd
@@ -262,7 +262,7 @@ rowRanges(x, ...) <- value
 
 \seealso{
   \itemize{
-    \item \link{SummarizedExperiment} objects.
+    \item \link{SummarizedExperiment-class}
 
     \item \link[SummarizedExperiment]{shift},
           \link[SummarizedExperiment]{isDisjoint},


### PR DESCRIPTION
Note. The `SummarizedExperiment` alias points to `RangedSummarizedExperiment` so we'd have to use the `SummarizedExperiment-class` link.