### PR TITLE
Use DelayedArray:::set_dimnames() in realize,SummarizedExperiment-method

### DIFF
--- a/R/SummarizedExperiment-class.R
+++ b/R/SummarizedExperiment-class.R
@@ -842,8 +842,8 @@ setMethod("realize", "SummarizedExperiment",
             ##      on disk doesn't store the dimnames in the HDF5 file at the
             ##      moment.
             a <- assay(x, i, withDimnames=FALSE)
-            dimnames(a) <- NULL
-            assay(x, i) <- realize(a, BACKEND=BACKEND)
+            a <- DelayedArray:::set_dimnames(a, NULL)
+            assay(x, i, withDimnames=FALSE) <- realize(a, BACKEND=BACKEND)
         }
         x
     }


### PR DESCRIPTION
Avoids unnecessarily degrading a HDF5Array to a DelayedArray in the realization.

Current behaviour:

``` r
suppressPackageStartupMessages(library(SummarizedExperiment))
se <- SummarizedExperiment(list(A = matrix(1:10), B = matrix(1:10)),
                           colData = DataFrame(row.names = "Z"))
sapply(assays(realize(se, "HDF5Array"), withDimnames = FALSE), class)
#> Loading required package: rhdf5
#>               A               B 
#> "DelayedMatrix"    "HDF5Matrix"
```

``` r
suppressPackageStartupMessages(library(SummarizedExperiment))
se <- SummarizedExperiment(list(A = matrix(1:10), B = matrix(1:10)),
                           colData = DataFrame(row.names = "Z"))
sapply(assays(realize(se, "HDF5Array"), withDimnames = FALSE), class)
#> Loading required package: rhdf5
#>            A            B 
#> "HDF5Matrix" "HDF5Matrix"
```