### PR TITLE
Type conversion btw SimpleAssays and list

### DIFF
--- a/R/Assays-class.R
+++ b/R/Assays-class.R
@@ -360,6 +360,13 @@ setAs("SimpleList", "SimpleAssays",
 
 setAs("SimpleAssays", "SimpleList", function(from) from@data)
 
+setAs("list", "SimpleAssays",
+      function(from) as(as(from, "SimpleList"),"SimpleAssays")
+)
+
+setAs("SimpleAssays", "list",
+      function(from) as(as(from, "SimpleList"),"list")
+)
 
 ### - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 ### ShallowSimpleListAssays class


### PR DESCRIPTION
From the document, only the coercion from/to SimpleList is required, but the class might be more flexible if the coercion from/to the list type is also available. The default coercion cannot automatically do this job and will throw an error.