### PR TITLE
Migrate SCE's flexible row combiner for general SE use.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,6 +28,7 @@ Collate: Assays-class.R
 	intra-range-methods.R
 	inter-range-methods.R
 	coverage-methods.R
+    combine-methods.R
 	findOverlaps-methods.R
 	nearest-methods.R
 	makeSummarizedExperimentFromExpressionSet.R

--- a/R/combine-methods.R
+++ b/R/combine-methods.R
@@ -1,22 +1,9 @@
 # Contains methods for combineRows and combineCols. These serve as more
 # fault-tolerant relaxed counterparts to rbind and cbind, respectively.
 
-setMethod("combineRows", c("SummarizedExperiment", "SummarizedExperiment"), function(x, y, ..., use.names=TRUE, delayed=TRUE, fill=NA) {
-    all.se <- list(x, y, ...)
-    .combine_rows_se(all.se, use.names=use.names, delayed=delayed, fill=fill)
-}) 
-
-setMethod("combineRows", c("missing", "SummarizedExperiment"), function(x, y, ..., use.names=TRUE, delayed=TRUE, fill=NA) {
-    all.se <- list(y, ...)
-    .combine_rows_se(all.se, use.names=use.names, delayed=delayed, fill=fill)
-}) 
-
-setMethod("combineRows", c("SummarizedExperiment", "missing"), function(x, y, ..., use.names=TRUE, delayed=TRUE, fill=NA) {
+setMethod("combineRows", "SummarizedExperiment", function(x, ..., use.names=TRUE, delayed=TRUE, fill=NA) {
     all.se <- list(x, ...)
-    .combine_rows_se(all.se, use.names=use.names, delayed=delayed, fill=fill)
-}) 
 
-.combine_rows_se <- function(all.se, use.names, delayed, fill) {
     # Combining the rowData.
     all.rd <- lapply(all.se, rowData) 
     tryCatch({
@@ -61,7 +48,7 @@ setMethod("combineRows", c("SummarizedExperiment", "missing"), function(x, y, ..
 
     # Assembling the SE.
     do.call(SummarizedExperiment, args)
-}
+})
 
 combine_assays_by_row <- function(all.se, mappings, delayed, fill) {
     all.assays <- lapply(all.se, assays, withDimnames=FALSE)

--- a/R/combine-methods.R
+++ b/R/combine-methods.R
@@ -1,9 +1,22 @@
 # Contains methods for combineRows and combineCols. These serve as more
 # fault-tolerant relaxed counterparts to rbind and cbind, respectively.
 
-setMethod("combineRows", "SummarizedExperiment", function(x, y, ..., use.names=TRUE, delayed=TRUE, fill=NA) {
+setMethod("combineRows", c("SummarizedExperiment", "SummarizedExperiment"), function(x, y, ..., use.names=TRUE, delayed=TRUE, fill=NA) {
     all.se <- list(x, y, ...)
+    .combine_rows_se(all.se, use.names=use.names, delayed=delayed, fill=fill)
+}) 
 
+setMethod("combineRows", c("missing", "SummarizedExperiment"), function(x, y, ..., use.names=TRUE, delayed=TRUE, fill=NA) {
+    all.se <- list(y, ...)
+    .combine_rows_se(all.se, use.names=use.names, delayed=delayed, fill=fill)
+}) 
+
+setMethod("combineRows", c("SummarizedExperiment", "missing"), function(x, y, ..., use.names=TRUE, delayed=TRUE, fill=NA) {
+    all.se <- list(x, ...)
+    .combine_rows_se(all.se, use.names=use.names, delayed=delayed, fill=fill)
+}) 
+
+.combine_rows_se <- function(all.se, use.names, delayed, fill) {
     # Combining the rowData.
     all.rd <- lapply(all.se, rowData) 
     tryCatch({
@@ -48,7 +61,7 @@ setMethod("combineRows", "SummarizedExperiment", function(x, y, ..., use.names=T
 
     # Assembling the SE.
     do.call(SummarizedExperiment, args)
-})
+}
 
 combine_assays_by_row <- function(all.se, mappings, delayed, fill) {
     all.assays <- lapply(all.se, assays, withDimnames=FALSE)

--- a/R/combine-methods.R
+++ b/R/combine-methods.R
@@ -1,0 +1,134 @@
+# Contains methods for combineRows and combineCols. These serve as more
+# fault-tolerant relaxed counterparts to rbind and cbind, respectively.
+
+setMethod("combineRows", "SummarizedExperiment", function(x, y, ..., use.names=TRUE, delayed=TRUE) {
+    all.se <- list(x, y, ...)
+
+    # Combining the rowData.
+    all.rd <- lapply(all.se, rowData) 
+    all.rd <- do.call(rbind, all.rd) # TODO: replace with combineRows for a DF.
+
+    # Combining the colData. This constructs mappings of the columns for each
+    # SE to the columns of the final object.
+    all.cd <- lapply(all.se, colData)
+
+    if (use.names) {
+        col.names <- lapply(all.se, colnames)
+        all.names <- Reduce(union, col.names)
+
+        mappings <- vector("list", length(all.se))
+        for (i in seq_along(mappings)) {
+            cur.names <- col.names[[i]]
+            if (is.null(cur.names) || anyDuplicated(cur.names)) {
+                stop(wmsg("each SummarizedExperiment must have non-NULL, ",
+                          "non-duplicated column names when 'use.names=TRUE'"))
+            }
+            mappings[[i]] <- match(all.names, cur.names)
+        }
+
+        for (i in seq_along(all.cd)) {
+            expanded <- all.cd[[i]][mappings[[i]],,drop=FALSE]
+            rownames(expanded) <- all.names
+            all.cd[[i]] <- expanded
+        }
+        all.cd <- do.call(cbind, all.cd) 
+
+    } else {
+        nc <- unique(vapply(all.se, ncol, 0L))
+        if (length(nc)!=1) {
+            stop(wmsg("all SummarizedExperiment objects must have the same ",
+                      "number of columns when 'use.names=FALSE'"))
+        }
+        mappings <- NULL
+
+        all.cd <- do.call(cbind, all.cd) 
+    }
+
+    # Assembling the SE.
+    SummarizedExperiment(
+        assays=.unsplit_assays(all.se, mappings, delayed=delayed),
+        colData=all.cd,
+        rowData=all.rd,
+        metadata=unlist(lapply(all.se, metadata), recursive=FALSE, use.names=FALSE)
+    )
+})
+
+.unsplit_assays <- function(all.se, mappings, delayed) {
+    all.assays <- unique(unlist(lapply(all.se, assayNames)))
+    combined <- vector("list", length(all.assays))
+    names(combined) <- all.assays
+
+    for (a in all.assays) {
+        current <- vector("list", length(all.se))
+
+        for (s in seq_along(all.se)) {
+            cur.se <- all.se[[s]]
+            i <- mappings[[s]]
+
+            if (a %in% assayNames(cur.se)) {
+                mat <- assay(cur.se, a, withDimnames=FALSE)
+                if (delayed) {
+                    mat <- DelayedArray(mat)
+                }
+
+                # Doing something to handle the missing columns, if there are any.
+                if (!is.null(i)) {
+                    absent <- is.na(i)
+                    if (any(absent)) {
+                        i[absent] <- ncol(mat)+1L
+                        mat <- cbind(mat, ConstantArray(c(nrow(cur.se), 1L), value=NA))
+                    }
+                    mat <- mat[,i,drop=FALSE]
+                }
+            } else {
+                if (is.null(i)) {
+                    nc <- ncol(cur.se)
+                } else {
+                    nc <- length(i)
+                }
+
+                mat <- ConstantArray(c(nrow(cur.se), nc), value=NA)
+                if (!delayed) {
+                    mat <- as.matrix(mat)
+                }
+            }
+
+            current[[s]] <- mat
+        }
+        combined[[a]] <- do.call(rbind, current)
+    }
+
+    combined
+}
+
+setMethod("combineRows", "RangedSummarizedExperiment", function(x, y, ..., use.names=TRUE, delayed=TRUE) {
+    out <- callNextMethod()
+
+    all.se <- list(x, y, ...)
+    final.rd <- vector("list", length(all.se))
+    for (s in seq_along(all.se)) {
+        cur.se <- all.se[[s]]
+        rr <- rowRanges(cur.se)
+        mcols(rr) <- NULL
+        final.rd[[s]] <- rr
+    }
+
+    # Filling in the empties. We promote everyone to a GRL if any of the individuals are GRLs.
+    has.grl <- any(vapply(final.rd, FUN=is, class2="GRangesList", FUN.VALUE=TRUE))
+    for (e in which(vapply(final.rd, is.null, FUN.VALUE=TRUE))) {
+        cur.se <- all.se[[e]]
+        if (has.grl) {
+            empty <- GRangesList(rep(list(GRanges()), nrow(cur.se)))
+        } else {
+            empty <- GRanges(rep("unknown:1-0", nrow(cur.se))) # TODO: a better convention for missing intervals?
+        }
+        mcols(empty) <- rowData(cur.se)
+        names(empty) <- rownames(cur.se)
+        final.rd[[e]] <- empty
+    }
+
+    rr <- do.call(c, final.rd)
+    mcols(rr) <- rowData(out)
+    rowRanges(out) <- rr
+    out 
+})

--- a/R/combine-methods.R
+++ b/R/combine-methods.R
@@ -6,99 +6,117 @@ setMethod("combineRows", "SummarizedExperiment", function(x, y, ..., use.names=T
 
     # Combining the rowData.
     all.rd <- lapply(all.se, rowData) 
-    all.rd <- do.call(rbind, all.rd) # TODO: replace with combineRows for a DF.
+    tryCatch({
+        com.rd <- do.call(combineRows, all.rd)
+    }, error=function(e) {
+        stop(paste0("failed to combine rowData of SummarizedExperiment objects:\n  ", conditionMessage(e)))
+    })
 
     # Combining the colData. This constructs mappings of the columns for each
     # SE to the columns of the final object.
     all.cd <- lapply(all.se, colData)
+    tryCatch({
+        com.cd <- do.call(combineCols, c(all.cd, list(use.names=use.names)))
+    }, error=function(e) {
+        stop(paste0("failed to combine colData of SummarizedExperiment objects:\n  ", conditionMessage(e)))
+    })
 
     if (use.names) {
-        col.names <- lapply(all.se, colnames)
-        all.names <- Reduce(union, col.names)
-
+        # If combineCols succeeded, all SE's should have valid row names.
+        all.names <- rownames(com.cd)
         mappings <- vector("list", length(all.se))
         for (i in seq_along(mappings)) {
-            cur.names <- col.names[[i]]
-            if (is.null(cur.names) || anyDuplicated(cur.names)) {
-                stop(wmsg("each SummarizedExperiment must have non-NULL, ",
-                          "non-duplicated column names when 'use.names=TRUE'"))
-            }
-            mappings[[i]] <- match(all.names, cur.names)
+            mappings[[i]] <- match(all.names, rownames(all.cd[[i]]))
         }
-
-        for (i in seq_along(all.cd)) {
-            expanded <- all.cd[[i]][mappings[[i]],,drop=FALSE]
-            rownames(expanded) <- all.names
-            all.cd[[i]] <- expanded
-        }
-        all.cd <- do.call(cbind, all.cd) 
-
     } else {
-        nc <- unique(vapply(all.se, ncol, 0L))
-        if (length(nc)!=1) {
-            stop(wmsg("all SummarizedExperiment objects must have the same ",
-                      "number of columns when 'use.names=FALSE'"))
-        }
         mappings <- NULL
-
-        all.cd <- do.call(cbind, all.cd) 
     }
 
     # Assembling the SE.
     SummarizedExperiment(
         assays=.unsplit_assays(all.se, mappings, delayed=delayed),
-        colData=all.cd,
-        rowData=all.rd,
+        colData=com.cd,
+        rowData=com.rd,
         metadata=unlist(lapply(all.se, metadata), recursive=FALSE, use.names=FALSE)
     )
 })
 
 .unsplit_assays <- function(all.se, mappings, delayed) {
-    all.assays <- unique(unlist(lapply(all.se, assayNames)))
-    combined <- vector("list", length(all.assays))
-    names(combined) <- all.assays
-
-    for (a in all.assays) {
-        current <- vector("list", length(all.se))
-
-        for (s in seq_along(all.se)) {
-            cur.se <- all.se[[s]]
-            i <- mappings[[s]]
-
-            if (a %in% assayNames(cur.se)) {
-                mat <- assay(cur.se, a, withDimnames=FALSE)
-                if (delayed) {
-                    mat <- DelayedArray(mat)
-                }
-
-                # Doing something to handle the missing columns, if there are any.
-                if (!is.null(i)) {
-                    absent <- is.na(i)
-                    if (any(absent)) {
-                        i[absent] <- ncol(mat)+1L
-                        mat <- cbind(mat, ConstantArray(c(nrow(cur.se), 1L), value=NA))
-                    }
-                    mat <- mat[,i,drop=FALSE]
-                }
-            } else {
-                if (is.null(i)) {
-                    nc <- ncol(cur.se)
-                } else {
-                    nc <- length(i)
-                }
-
-                mat <- ConstantArray(c(nrow(cur.se), nc), value=NA)
-                if (!delayed) {
-                    mat <- as.matrix(mat)
-                }
-            }
-
-            current[[s]] <- mat
+    all.assays <- lapply(all.se, assays, withDimnames=FALSE)
+    each.assay.names <- lapply(all.assays, names)
+    no.assay.names <- vapply(each.assay.names, is.null, TRUE)
+    
+    create_dummy <- function(nr, nc) {
+        if (!delayed) {
+            array(c(nr, nc), data=NA)
+        } else {
+            ConstantArray(c(nr, nc), value=NA)
         }
-        combined[[a]] <- do.call(rbind, current)
     }
 
-    combined
+    inflate_existing <- function(mat, i) {
+        if (delayed) {
+            mat <- DelayedArray(mat)
+        }
+        if (!is.null(i)) {
+            absent <- is.na(i)
+            if (any(absent)) {
+                i[absent] <- ncol(mat)+1L
+                mat <- cbind(mat, create_dummy(nrow(mat), 1L))
+            }
+            mat <- mat[,i,drop=FALSE]
+        }
+        mat
+    }
+
+    if (any(no.assay.names)) {
+        if (!all(no.assay.names)) {
+            stop("named and unnamed assays cannot be mixed")
+        }
+        n.assays <- unique(lengths(all.assays))
+        if (length(n.assays)!=1L) {
+            stop("all SummarizedExperiments should have the same number of unnamed assays")
+        }
+        for (s in seq_along(all.se)) {
+            cur.assays <- all.assays[[s]]
+            i <- mappings[[s]]
+
+            # Filling in all missing columns.
+            for (a in seq_len(n.assays)) {
+                mat <- inflate_existing(cur.assays[[a]], i)
+                cur.assays[[a]] <- mat
+            }
+            all.assays[[s]] <- cur.assays
+        }
+    } else {
+        all.assay.names <- Reduce(union, each.assay.names)
+        for (s in seq_along(all.se)) {
+            cur.se <- all.se[[s]]
+            cur.assays <- all.assays[[s]]
+            i <- mappings[[s]]
+
+            # Filling in all missing assay names and columns.
+            for (a in all.assay.names) {
+                if (a %in% names(cur.assays)) {
+                    mat <- inflate_existing(cur.assays[[a]], i)
+                } else {
+                    if (is.null(i)) {
+                        nc <- ncol(cur.se)
+                    } else {
+                        nc <- length(i)
+                    }
+                    mat <- create_dummy(nrow(cur.se), nc)
+                }
+                cur.assays[[a]] <- mat
+            }
+            all.assays[[s]] <- cur.assays
+        }
+    }
+
+    # Re-use assay rbind'ing machinery.
+    all.assays <- lapply(all.assays, Assays)
+    combined <- do.call(rbind, all.assays)
+    as(combined, "SimpleList") 
 }
 
 setMethod("combineRows", "RangedSummarizedExperiment", function(x, y, ..., use.names=TRUE, delayed=TRUE) {
@@ -113,14 +131,16 @@ setMethod("combineRows", "RangedSummarizedExperiment", function(x, y, ..., use.n
         final.rd[[s]] <- rr
     }
 
-    # Filling in the empties. We promote everyone to a GRL if any of the individuals are GRLs.
+    # Filling in the empties. We promote everyone to a GRL if any of the
+    # individual entries are GRLs.
     has.grl <- any(vapply(final.rd, FUN=is, class2="GRangesList", FUN.VALUE=TRUE))
     for (e in which(vapply(final.rd, is.null, FUN.VALUE=TRUE))) {
         cur.se <- all.se[[e]]
         if (has.grl) {
             empty <- GRangesList(rep(list(GRanges()), nrow(cur.se)))
         } else {
-            empty <- GRanges(rep("unknown:1-0", nrow(cur.se))) # TODO: a better convention for missing intervals?
+            # TODO: a better convention for missing intervals?
+            empty <- GRanges(rep("unknown:1-0", nrow(cur.se))) 
         }
         mcols(empty) <- rowData(cur.se)
         names(empty) <- rownames(cur.se)

--- a/inst/unitTests/test_combine-methods.R
+++ b/inst/unitTests/test_combine-methods.R
@@ -112,12 +112,182 @@ test_combineRows_ranges <- function() {
     suppressWarnings(out <- combineRows(se, se2, use.names=FALSE))
     checkIdentical(rowRanges(out), suppressWarnings(c(rowRanges(se), rowRanges(se2))))
 
-    rowRanges(se2) <- NULL
-    suppressWarnings(out <- combineRows(se, se2, use.names=FALSE))
+    # Testing different objects.
+    se3 <- se2
+    rowRanges(se3) <- NULL
+    suppressWarnings(out <- combineRows(se, se3, use.names=FALSE))
     checkTrue(is(rowRanges(out), "GRangesList"))
-    checkIdentical(rownames(out), c(rownames(se), rownames(se2)))
+    checkIdentical(rownames(out), c(rownames(se), rownames(se3)))
 
-    # Order doesn't matter.
-    suppressWarnings(out <- combineRows(se2, se, use.names=FALSE))
+    se4 <- se2
+    rowRanges(se4) <- as(rowRanges(se4), "GRangesList")
+    suppressWarnings(out <- combineRows(se, se4, use.names=FALSE))
     checkTrue(is(rowRanges(out), "GRangesList"))
+    checkIdentical(unname(lengths(rowRanges(out))), rep(1L, 200))
+
+    # Order doesn't affect conversion to GRL.
+    suppressWarnings(out <- combineRows(se3, se, use.names=FALSE))
+    checkTrue(is(rowRanges(out), "GRangesList"))
+
+    suppressWarnings(combined <- rowRanges(combineRows(se, se3, se4, use.names=FALSE)))
+    checkIdentical(unname(lengths(combined)), rep(c(1L, 0L, 1L), c(nrow(se), nrow(se3), nrow(se4))))
+    suppressWarnings(combined <- rowRanges(combineRows(se3, se, se4, use.names=FALSE)))
+    checkIdentical(unname(lengths(combined)), rep(c(0L, 1L, 1L), c(nrow(se3), nrow(se), nrow(se4))))
+}
+
+test_combineCols_unnamed <- function() {
+    se <- SummarizedExperiment(list(counts=matrix(rpois(1000, 10), ncol=10)))
+    colData(se)$A <- 1L
+    rowData(se)$A <- 1
+
+    se2 <- SummarizedExperiment(list(counts=matrix(rpois(1000, 10), ncol=10), 
+        normalized=matrix(rnorm(1000), ncol=10)))
+    colData(se2)$A <- 2L
+    colData(se2)$B <- 3
+    rowData(se2)$B <- "B"
+
+    stuff <- combineCols(se, se2, use.names=FALSE)
+
+    # Column data is correctly combined.
+    checkIdentical(stuff$A, rep(1:2, each=10))
+    checkIdentical(stuff$B, rep(c(NA, 3), each=10))
+
+    # Row data is correctly combined.
+    checkIdentical(rowData(stuff)$A, rep(1, nrow(se)))
+    checkIdentical(rowData(stuff)$B, rep("B", nrow(se)))
+
+    # Assay data is correctly combined.
+    checkIdentical(as.matrix(assay(stuff)), cbind(assay(se), assay(se2)))
+    checkIdentical(as.matrix(assay(stuff, 2)), cbind(matrix(NA, nrow(se), ncol(se)), assay(se2, 2)))
+
+    # Unary methods work as expected.
+    checkIdentical(se, combineCols(se, delayed=FALSE, use.names=FALSE))
+}
+
+test_combineCols_named <- function() {
+    se <- SummarizedExperiment(list(counts=matrix(rpois(1000, 10), ncol=100)))
+    colData(se)$A <- 1L
+    rowData(se)$A <- 1
+
+    se2 <- SummarizedExperiment(list(counts=matrix(rpois(1000, 10), ncol=50), 
+        normalized=matrix(rnorm(1000), ncol=50)))
+    colData(se2)$A <- 2L
+    colData(se2)$B <- 3
+    rowData(se2)$B <- "B"
+
+    # This fails, because we expect matching numbers of columns when use.names=TRUE.
+    checkException(combineCols(se, se2), silent=TRUE)
+
+    rownames(se) <- letters[1:10]
+    rownames(se2) <- letters[3:22]
+    stuff <- combineCols(se, se2)
+
+    # Column data is correctly combined
+    checkIdentical(rownames(stuff), letters[1:22])
+    checkIdentical(stuff$A, rep(1:2, c(ncol(se), ncol(se2))))
+    checkIdentical(stuff$B, rep(c(NA, 3), c(ncol(se), ncol(se2))))
+
+    # Row data is correctly combined.
+    checkIdentical(rowData(stuff)$A, rep(c(1, NA), c(nrow(se), 12)))
+    checkIdentical(rowData(stuff)$B, rep(c(NA, "B"), c(2, nrow(se2))))
+
+    # Assay data is correctly combined.
+    mat <- as.matrix(assay(stuff))
+    ref <- cbind(
+        rbind(assay(se), matrix(NA, 12, ncol(se))),
+        rbind(NA, NA, assay(se2))
+    )
+    rownames(ref) <- letters[1:22]
+    checkIdentical(mat, ref)
+
+    mat <- as.matrix(assay(stuff, 2))
+    ref <- cbind(
+        matrix(NA, nrow(stuff), ncol(se)),
+        rbind(NA, NA, assay(se2, 2))
+    )
+    rownames(ref) <- letters[1:22]
+    checkIdentical(mat, ref)
+
+    # Unary methods work as expected.
+    checkIdentical(se, combineCols(se, delayed=FALSE))
+}
+
+test_combineCols_assays <- function() {
+    # Deep dive into correct assay name behavior.
+    se <- SummarizedExperiment(list(matrix(rpois(1000, 10), ncol=10)))
+    se2 <- SummarizedExperiment(list(matrix(rpois(1000, 10), ncol=10), 
+        matrix(rnorm(1000), ncol=10)))
+    colnames(se) <- letters[1:10]
+    colnames(se2) <- letters[15:24]
+    rownames(se) <- paste0("GENE_", 1:100)
+    rownames(se2) <- paste0("SPIKE_", 1:100)
+
+    # This should fail due to differences in the number of _unnamed_ assays.
+    checkException(combineCols(se, se2), silent=TRUE)
+
+    # Either all assays are named, or all are unnamed.
+    assays(se) <- assays(se)[c(1, 1)]
+    assayNames(se2) <- c("WHEE", "BLAH")
+    checkException(combineCols(se, se2), silent=TRUE)
+
+    assays(se2) <- unname(assays(se2))
+    out <- combineCols(se, se2)
+    checkIdentical(colnames(out), letters[c(1:10, 15:24)])
+    checkIdentical(rownames(out), c(rownames(se), rownames(se2)))
+}
+
+test_combineCols_ranges <- function() {
+    se <- SummarizedExperiment(list(counts=matrix(rpois(1000, 10), ncol=10)))
+    se2 <- SummarizedExperiment(list(counts=matrix(rpois(1000, 10), ncol=10)))
+    rownames(se) <- paste0("GENE_", 1:100)
+    rownames(se2) <- paste0("GENE_", 21:120)
+
+    # Checking that an SE is returned.
+    out <- combineCols(se, se2, use.names=FALSE)
+    checkIdentical(as.character(class(out)), "SummarizedExperiment")
+    checkIdentical(rownames(out), rownames(se)) # ignoring other row names when use.names=FALSE.
+
+    out <- combineCols(se, se2)
+    checkIdentical(as.character(class(out)), "SummarizedExperiment")
+    checkIdentical(rownames(out), union(rownames(se), rownames(se2))) 
+
+    # Checking that an RSE is returned.
+    seqinfo <- Seqinfo(seqlengths=c(chrA=1000))
+    rowRanges(se) <- GRanges("chrA", IRanges(1, 1:100), seqinfo=seqinfo)
+    rowRanges(se2) <- GRanges("chrA", IRanges(1, 21:120), seqinfo=seqinfo)
+
+    suppressWarnings(out <- combineCols(se, se2, use.names=FALSE)) # should have a warning here due to differences in values.
+    checkIdentical(as.character(class(out)), "RangedSummarizedExperiment")
+    checkIdentical(rowRanges(out), rowRanges(se)) 
+
+    rownames(se) <- paste0("GENE_", 1:100) # adding back the names.
+    rownames(se2) <- paste0("GENE_", 21:120)
+    out <- combineCols(se, se2)
+    ref <- GRanges("chrA", IRanges(1, 1:120), seqinfo=seqinfo)
+    names(ref) <- paste0("GENE_", 1:120)
+    checkIdentical(rowRanges(out), ref)
+
+    # Checking that mixtures of objects work.
+    se3 <- se2
+    rowRanges(se3) <- NULL
+    rownames(se3) <- paste0("GENE_", 21:120)
+
+    out <- combineCols(se, se3)
+    checkTrue(is(rowRanges(out), "GRangesList"))
+    checkIdentical(rownames(out), paste0("GENE_", 1:120)) 
+    checkIdentical(unname(lengths(rowRanges(out))), rep(1:0, c(100, 20))) 
+
+    suppressWarnings(out <- combineCols(se3, se, use.names=FALSE)) # flipping the order.
+    checkTrue(is(rowRanges(out), "GRangesList"))
+
+    se4 <- tail(se2, 20)
+    rowRanges(se4) <- as(rowRanges(se4), "GRangesList")
+    out <- combineCols(se, se4)
+    checkTrue(is(rowRanges(out), "GRangesList"))
+    checkIdentical(rownames(out), paste0("GENE_", 1:120)) 
+    checkIdentical(unname(lengths(rowRanges(out))), rep(1L, 120))
+
+    checkIdentical(rowRanges(out), rowRanges(combineCols(se, se3, se4)))
+    checkIdentical(rowRanges(out), rowRanges(combineCols(se3, se, se4))[rownames(out)]) # ignoring the ordering for this check.
+    checkIdentical(rowRanges(out), rowRanges(combineCols(se3, se4, se))[rownames(out)])
 }

--- a/inst/unitTests/test_combine-methods.R
+++ b/inst/unitTests/test_combine-methods.R
@@ -23,8 +23,7 @@ test_combineRows_unnamed <- function() {
     checkIdentical(as.matrix(assay(stuff, 2)), rbind(matrix(NA, nrow(se), ncol(se)), assay(se2, 2)))
 
     # Unary methods work as expected.
-    checkIdentical(se, combineRows(x=se, delayed=FALSE, use.names=FALSE))
-    checkIdentical(se, combineRows(y=se, delayed=FALSE, use.names=FALSE))
+    checkIdentical(se, combineRows(se, delayed=FALSE, use.names=FALSE))
 }
 
 test_combineRows_named <- function() {
@@ -71,8 +70,7 @@ test_combineRows_named <- function() {
     checkIdentical(mat, ref)
 
     # Unary methods work as expected.
-    checkIdentical(se, combineRows(x=se, delayed=FALSE))
-    checkIdentical(se, combineRows(y=se, delayed=FALSE))
+    checkIdentical(se, combineRows(se, delayed=FALSE))
 }
 
 test_combineRows_assays <- function() {

--- a/inst/unitTests/test_combine-methods.R
+++ b/inst/unitTests/test_combine-methods.R
@@ -21,6 +21,10 @@ test_combineRows_unnamed <- function() {
     # Assay data is correctly combined.
     checkIdentical(as.matrix(assay(stuff)), rbind(assay(se), assay(se2)))
     checkIdentical(as.matrix(assay(stuff, 2)), rbind(matrix(NA, nrow(se), ncol(se)), assay(se2, 2)))
+
+    # Unary methods work as expected.
+    checkIdentical(se, combineRows(x=se, delayed=FALSE, use.names=FALSE))
+    checkIdentical(se, combineRows(y=se, delayed=FALSE, use.names=FALSE))
 }
 
 test_combineRows_named <- function() {
@@ -65,6 +69,10 @@ test_combineRows_named <- function() {
     )
     colnames(ref) <- letters[1:22]
     checkIdentical(mat, ref)
+
+    # Unary methods work as expected.
+    checkIdentical(se, combineRows(x=se, delayed=FALSE))
+    checkIdentical(se, combineRows(y=se, delayed=FALSE))
 }
 
 test_combineRows_assays <- function() {

--- a/inst/unitTests/test_combine-methods.R
+++ b/inst/unitTests/test_combine-methods.R
@@ -77,7 +77,7 @@ test_combineRows_assays <- function() {
     rownames(se) <- paste0("GENE_", 1:100)
     rownames(se2) <- paste0("SPIKE_", 1:100)
 
-    # This should fail due to differences in the number of assays.
+    # This should fail due to differences in the number of _unnamed_ assays.
     checkException(combineRows(se, se2), silent=TRUE)
 
     # Either all assays are named, or all are unnamed.

--- a/inst/unitTests/test_combine-methods.R
+++ b/inst/unitTests/test_combine-methods.R
@@ -1,0 +1,92 @@
+test_combineRows_unnamed <- function() {
+    se <- SummarizedExperiment(list(counts=matrix(rpois(1000, 10), ncol=10)))
+    colData(se)$A <- 1
+    rowData(se)$A <- 1
+
+    se2 <- SummarizedExperiment(list(counts=matrix(rpois(1000, 10), ncol=10), 
+        normalized=matrix(rnorm(1000), ncol=10)))
+    colData(se2)$B <- 2
+    rowData(se2)$B <- "B"
+
+    stuff <- combineRows(se, se2, use.names=FALSE)
+
+    # Column data is correctly combined.
+    checkIdentical(stuff$A, rep(1, ncol(stuff)))
+    checkIdentical(stuff$B, rep(2, ncol(stuff)))
+
+    # Row data is correctly combined.
+    checkIdentical(rowData(stuff)$A, rep(c(1, NA), c(nrow(se), nrow(se2))))
+    checkIdentical(rowData(stuff)$B, rep(c(NA, "B"), c(nrow(se), nrow(se2))))
+
+    # Assay data is correctly combined.
+    checkIdentical(as.matrix(assay(stuff)), rbind(assay(se), assay(se2)))
+    checkIdentical(as.matrix(assay(stuff, 2)), rbind(matrix(NA, nrow(se), ncol(se)), assay(se2, 2)))
+}
+
+test_combineRows_named <- function() {
+    se <- SummarizedExperiment(list(counts=matrix(rpois(1000, 10), ncol=10)))
+    colData(se)$A <- 1
+    rowData(se)$A <- 1
+
+    se2 <- SummarizedExperiment(list(counts=matrix(rpois(1000, 10), ncol=20), 
+        normalized=matrix(rnorm(1000), ncol=20)))
+    colData(se2)$B <- 2
+    rowData(se2)$B <- "B"
+
+    # This fails, because we expect matching numbers of columns when use.names=TRUE.
+    checkException(combineRows(se, se2), silent=TRUE)
+
+    colnames(se) <- letters[1:10]
+    colnames(se2) <- letters[3:22]
+    stuff <- combineRows(se, se2)
+
+    # Column data is correctly combined
+    checkIdentical(colnames(stuff), letters[1:22])
+    checkIdentical(stuff$A, rep(c(1, NA), c(ncol(se), 12)))
+    checkIdentical(stuff$B, rep(c(NA, 2), c(2, ncol(se2))))
+
+    # Row data is correctly combined.
+    checkIdentical(rowData(stuff)$A, rep(c(1, NA), c(nrow(se), nrow(se2))))
+    checkIdentical(rowData(stuff)$B, rep(c(NA, "B"), c(nrow(se), nrow(se2))))
+
+    # Assay data is correctly combined.
+    mat <- as.matrix(assay(stuff))
+    ref <- rbind(
+        cbind(assay(se), matrix(NA, nrow(se), ncol=12)),
+        cbind(NA, NA, assay(se2))
+    )
+    colnames(ref) <- letters[1:22]
+    checkIdentical(mat, ref)
+
+    mat <- as.matrix(assay(stuff, 2))
+    ref <- rbind(
+        matrix(NA, nrow(se), ncol(stuff)),
+        cbind(NA, NA, assay(se2, 2))
+    )
+    colnames(ref) <- letters[1:22]
+    checkIdentical(mat, ref)
+}
+
+test_combineRows_assays <- function() {
+    # Deep dive into correct assay name behavior.
+    se <- SummarizedExperiment(list(matrix(rpois(1000, 10), ncol=10)))
+    se2 <- SummarizedExperiment(list(matrix(rpois(1000, 10), ncol=10), 
+        matrix(rnorm(1000), ncol=10)))
+    colnames(se) <- letters[1:10]
+    colnames(se2) <- letters[15:24]
+    rownames(se) <- paste0("GENE_", 1:100)
+    rownames(se2) <- paste0("SPIKE_", 1:100)
+
+    # This should fail due to differences in the number of assays.
+    checkException(combineRows(se, se2), silent=TRUE)
+
+    # Either all assays are named, or all are unnamed.
+    assays(se) <- assays(se)[c(1, 1)]
+    assayNames(se2) <- c("WHEE", "BLAH")
+    checkException(combineRows(se, se2), silent=TRUE)
+
+    assays(se2) <- unname(assays(se2))
+    out <- combineRows(se, se2)
+    checkIdentical(colnames(out), letters[c(1:10, 15:24)])
+    checkIdentical(rownames(out), c(rownames(se), rownames(se2)))
+}

--- a/inst/unitTests/test_combine-methods.R
+++ b/inst/unitTests/test_combine-methods.R
@@ -90,3 +90,28 @@ test_combineRows_assays <- function() {
     checkIdentical(colnames(out), letters[c(1:10, 15:24)])
     checkIdentical(rownames(out), c(rownames(se), rownames(se2)))
 }
+
+test_combineRows_ranges <- function() {
+    se <- SummarizedExperiment(list(counts=matrix(rpois(1000, 10), ncol=10)))
+    se2 <- SummarizedExperiment(list(counts=matrix(rpois(1000, 10), ncol=10)))
+    rownames(se) <- paste0("GENE_", 1:100)
+    rownames(se2) <- paste0("SPIKE_", 1:100)
+
+    out <- combineRows(se, se2, use.names=FALSE)
+    checkIdentical(as.character(class(out)), "SummarizedExperiment")
+    checkIdentical(rownames(out), c(rownames(se), rownames(se2)))
+
+    rowRanges(se) <- GRanges("chrA", IRanges(1, 1:100))
+    rowRanges(se2) <- GRanges("chrB", IRanges(1, 1:100))
+    suppressWarnings(out <- combineRows(se, se2, use.names=FALSE))
+    checkIdentical(rowRanges(out), suppressWarnings(c(rowRanges(se), rowRanges(se2))))
+
+    rowRanges(se2) <- NULL
+    suppressWarnings(out <- combineRows(se, se2, use.names=FALSE))
+    checkTrue(is(rowRanges(out), "GRangesList"))
+    checkIdentical(rownames(out), c(rownames(se), rownames(se2)))
+
+    # Order doesn't matter.
+    suppressWarnings(out <- combineRows(se2, se, use.names=FALSE))
+    checkTrue(is(rowRanges(out), "GRangesList"))
+}

--- a/man/SummarizedExperiment-class.Rd
+++ b/man/SummarizedExperiment-class.Rd
@@ -68,6 +68,8 @@
 \alias{cbind,SummarizedExperiment-method}
 \alias{combineRows}
 \alias{combineRows,SummarizedExperiment-method}
+\alias{combineCols}
+\alias{combineCols,SummarizedExperiment-method}
 
 % On-disk realization
 \alias{realize,SummarizedExperiment-method}
@@ -451,6 +453,60 @@ colData(x, ...) <- value
       with no name checking.
     }
 
+    \item{\code{combineCols(x, ..., use.names=TRUE, delayed=TRUE, fill=NA)}:}{
+      \code{combineCols} acts like more flexible \code{cbind}, returning a
+      SummarizedExperiment with columns equal to the concatenation of columns 
+      across all input objects. Unlike \code{cbind}, it permits differences in
+      the number and identity of the rows, differences in the available
+      \code{\link{colData}} fields, and even differences in the available
+      \code{\link{assays}} among the objects being combined.
+
+      If \code{use.names=TRUE}, each input object must have non-\code{NULL},
+      non-duplicated row names. These names do not have to be the same, or
+      even shared, across the input objects. The row names of the returned
+      \code{SummarizedExperiment} will be a union of the row names across
+      all input objects. If a row is not present in an input, the
+      corresponding assay and \code{rowData} entries will be filled with
+      \code{fill} and \code{NA}s, respectively, in the combined
+      SummarizedExperiment.
+
+      If \code{use.names=FALSE}, all objects must have the same number of rows.
+      The row names of the returned object is set to \code{rownames(x)}. Any
+      differences in the row names between input objects are ignored.
+
+      Data in \code{assays} are combined by matching the names of the assays.
+      If one input object does not contain a named assay present in other input
+      objects, the corresponding assay entries in the returned object will be
+      set to \code{fill}. If all assay names are NULL, matching is done by
+      position. A mixture of named and unnamed assays will throw an error.
+
+      If \code{delayed=TRUE}, assay matrices are wrapped in
+      \code{\link{DelayedArray}}s to avoid any extra memory allocation during
+      the matrix \code{rbind}ing. Otherwise, the matrices are combined as-is;
+      note that this may still return \code{DelayedMatrix}s if the inputs were
+      also \code{DelayedMatrix} objects.
+
+      If any input is a \code{RangedSummarizedExperiment}, the returned object
+      will also be a \code{RangedSummarizedExperiment}. The \code{rowRanges} of
+      the returned object is set to a merge of the \code{rowRanges} of all
+      inputs, where the coordinates for each row are taken from the input
+      object that contains that row. Any conflicting ranges for shared rows
+      will raise a warning and all \code{rowRanges} information from the
+      offending \code{RangedSummarizedExperiment} will be ignored. If any
+      input is a \code{SummarizedExperiment}, the returned \code{rowRanges} is
+      converted into a \code{GRangesList} and the entries corresponding to the
+      unique rows of the \code{SummarizedExperiment} are set to zero-length
+      \code{GRanges}. If all inputs are \code{SummarizedExperiment} objects, a
+      \code{SummarizedExperiment} is also returned.
+
+      \code{colData} are combined using \code{\link{combineCols}} for
+      \code{DataFrame} objects. It is not necessary for all input objects to
+      have the same fields in their \code{rowData}; missing fields are filled
+      with \code{NA}s for the corresponding rows in the returned object.
+
+      \code{metadata} from all objects are combined into a \code{list}
+      with no name checking.
+    }
   }
 
 }

--- a/man/SummarizedExperiment-class.Rd
+++ b/man/SummarizedExperiment-class.Rd
@@ -499,10 +499,10 @@ colData(x, ...) <- value
       \code{GRanges}. If all inputs are \code{SummarizedExperiment} objects, a
       \code{SummarizedExperiment} is also returned.
 
-      \code{colData} are combined using \code{\link{combineCols}} for
+      \code{colData} are combined using \code{\link{combineRows}} for
       \code{DataFrame} objects. It is not necessary for all input objects to
-      have the same fields in their \code{rowData}; missing fields are filled
-      with \code{NA}s for the corresponding rows in the returned object.
+      have the same fields in their \code{colData}; missing fields are filled
+      with \code{NA}s for the corresponding columns in the returned object.
 
       \code{metadata} from all objects are combined into a \code{list}
       with no name checking.

--- a/man/SummarizedExperiment-class.Rd
+++ b/man/SummarizedExperiment-class.Rd
@@ -398,7 +398,7 @@ colData(x, ...) <- value
       with no name checking.
     }
 
-    \item{\code{combineRows(x, y, ..., use.names=TRUE, delayed=TRUE)}:}{
+    \item{\code{combineRows(x, y, ..., use.names=TRUE, delayed=TRUE, fill=NA)}:}{
       \code{combineRows} acts like more flexible \code{rbind}, returning a
       SummarizedExperiment with features equal to the concatenation of features
       across all input objects. Unlike \code{rbind}, it permits differences in
@@ -412,7 +412,8 @@ colData(x, ...) <- value
       \code{SummarizedExperiment} will be a union of the column names across
       all input objects. If a column is not present in an input, the
       corresponding assay and \code{colData} entries will be filled with
-      \code{NA}s in the combined SummarizedExperiment.
+      \code{fill} and \code{NA}s, respectively, in the combined
+      SummarizedExperiment.
 
       If \code{use.names=FALSE}, all objects must have the same number of
       columns. The column names of the returned object is set to
@@ -422,7 +423,7 @@ colData(x, ...) <- value
       Data in \code{assays} are combined by matching the names of the assays.
       If one input object does not contain a named assay present in other input
       objects, the corresponding assay entries in the returned object will be
-      set to \code{NA}. If all assay names are NULL, matching is done by
+      set to \code{fill}. If all assay names are NULL, matching is done by
       position. A mixture of named and unnamed assays will throw an error.
 
       If \code{delayed=TRUE}, assay matrices are wrapped in

--- a/man/SummarizedExperiment-class.Rd
+++ b/man/SummarizedExperiment-class.Rd
@@ -67,7 +67,9 @@
 \alias{rbind,SummarizedExperiment-method}
 \alias{cbind,SummarizedExperiment-method}
 \alias{combineRows}
-\alias{combineRows,SummarizedExperiment-method}
+\alias{combineRows,SummarizedExperiment,SummarizedExperiment-method}
+\alias{combineRows,SummarizedExperiment,missing-method}
+\alias{combineRows,missing,SummarizedExperiment-method}
 
 % On-disk realization
 \alias{realize,SummarizedExperiment-method}

--- a/man/SummarizedExperiment-class.Rd
+++ b/man/SummarizedExperiment-class.Rd
@@ -359,8 +359,8 @@ colData(x, ...) <- value
 
 \section{Combining}{
 
-  In the code snippets below, \code{...} are SummarizedExperiment objects
-  to be combined.
+  In the code snippets below, \code{x}, \code{y} and \code{...} are
+  SummarizedExperiment objects to be combined.
 
   \describe{
 
@@ -391,6 +391,43 @@ colData(x, ...) <- value
       Data in \code{assays} are combined by name matching; if all assay
       names are NULL matching is by position. A mixture of names and NULL
       throws an error.
+
+      \code{metadata} from all objects are combined into a \code{list}
+      with no name checking.
+    }
+
+    \item{\code{combineRows(x, y, ..., use.names=TRUE, delayed=TRUE)}:}{
+      \code{combineRows} acts much like more flexible \code{rbind}, returning a
+      SummarizedExperiment with features equal to the concatenation of features
+      across all input objects. Unlike \code{rbind}, it permits differences in
+      the number and identity of the columns, differences in the available
+      \code{\link{rowData}} fields, and even differences in the available
+      \code{\link{assays}} among the objects being combined.
+
+      If \code{use.names=TRUE}, each input object must have non-\code{NULL},
+      non-duplicated column names. These names do not have to be the same, or
+      even shared, across the input objects. The column names of the returned
+      \code{SummarizedExperiment} will be a union of the column names across
+      all input objects. If a column is not present in an input, the
+      corresponding assay and \code{colData} entries will be filled with
+      \code{NA}s in the combined SummarizedExperiment.
+
+      If \code{use.names=FALSE}, all objects must have the same number of
+      columns. The column names of the returned object is set to
+      \code{colnames(x)}. Any differences in the column names between input
+      objects are ignored.
+
+      Data in \code{assays} are combined by name matching. If an input object
+      does not contain a named assay, the corresponding entries of the combined
+      assay will be set to \code{NA}. If all assay names are NULL, matching is
+      done by position. A mixture of named and unnamed assays will throw an
+      error.
+
+      If \code{delayed=TRUE}, assay matrices are wrapped in
+      \code{\link{DelayedArray}}s to avoid any extra memory allocation during
+      the matrix \code{rbind}ing. Otherwise, the matrices are combined as-is;
+      note that this may still return \code{DelayedMatrix}s if the inputs were
+      also \code{DelayedMatrix} objects.
 
       \code{metadata} from all objects are combined into a \code{list}
       with no name checking.

--- a/man/SummarizedExperiment-class.Rd
+++ b/man/SummarizedExperiment-class.Rd
@@ -417,11 +417,11 @@ colData(x, ...) <- value
       \code{colnames(x)}. Any differences in the column names between input
       objects are ignored.
 
-      Data in \code{assays} are combined by name matching. If an input object
-      does not contain a named assay, the corresponding entries of the combined
-      assay will be set to \code{NA}. If all assay names are NULL, matching is
-      done by position. A mixture of named and unnamed assays will throw an
-      error.
+      Data in \code{assays} are combined by matching the names of the assays.
+      If one input object does not contain a named assay present in other input
+      objects, the corresponding assay entries in the returned object will be
+      set to \code{NA}. If all assay names are NULL, matching is done by
+      position. A mixture of named and unnamed assays will throw an error.
 
       If \code{delayed=TRUE}, assay matrices are wrapped in
       \code{\link{DelayedArray}}s to avoid any extra memory allocation during

--- a/man/SummarizedExperiment-class.Rd
+++ b/man/SummarizedExperiment-class.Rd
@@ -66,6 +66,8 @@
 % Combine
 \alias{rbind,SummarizedExperiment-method}
 \alias{cbind,SummarizedExperiment-method}
+\alias{combineRows}
+\alias{combineRows,SummarizedExperiment-method}
 
 % On-disk realization
 \alias{realize,SummarizedExperiment-method}
@@ -397,7 +399,7 @@ colData(x, ...) <- value
     }
 
     \item{\code{combineRows(x, y, ..., use.names=TRUE, delayed=TRUE)}:}{
-      \code{combineRows} acts much like more flexible \code{rbind}, returning a
+      \code{combineRows} acts like more flexible \code{rbind}, returning a
       SummarizedExperiment with features equal to the concatenation of features
       across all input objects. Unlike \code{rbind}, it permits differences in
       the number and identity of the columns, differences in the available

--- a/man/SummarizedExperiment-class.Rd
+++ b/man/SummarizedExperiment-class.Rd
@@ -67,9 +67,7 @@
 \alias{rbind,SummarizedExperiment-method}
 \alias{cbind,SummarizedExperiment-method}
 \alias{combineRows}
-\alias{combineRows,SummarizedExperiment,SummarizedExperiment-method}
-\alias{combineRows,SummarizedExperiment,missing-method}
-\alias{combineRows,missing,SummarizedExperiment-method}
+\alias{combineRows,SummarizedExperiment-method}
 
 % On-disk realization
 \alias{realize,SummarizedExperiment-method}
@@ -400,7 +398,7 @@ colData(x, ...) <- value
       with no name checking.
     }
 
-    \item{\code{combineRows(x, y, ..., use.names=TRUE, delayed=TRUE, fill=NA)}:}{
+    \item{\code{combineRows(x, ..., use.names=TRUE, delayed=TRUE, fill=NA)}:}{
       \code{combineRows} acts like more flexible \code{rbind}, returning a
       SummarizedExperiment with features equal to the concatenation of features
       across all input objects. Unlike \code{rbind}, it permits differences in

--- a/man/SummarizedExperiment-class.Rd
+++ b/man/SummarizedExperiment-class.Rd
@@ -429,6 +429,21 @@ colData(x, ...) <- value
       note that this may still return \code{DelayedMatrix}s if the inputs were
       also \code{DelayedMatrix} objects.
 
+      If any input is a \code{RangedSummarizedExperiment}, the returned object
+      will also be a \code{RangedSummarizedExperiment}. The \code{rowRanges} of
+      the returned object is set to the concatenation of the \code{rowRanges}
+      of all inputs. If any input is a \code{SummarizedExperiment}, the
+      returned \code{rowRanges} is converted into a \code{GRangesList} and the
+      entries corresponding to the rows of the \code{SummarizedExperiment} are
+      set to zero-length \code{GRanges}. If all inputs are
+      \code{SummarizedExperiment} objects, a \code{SummarizedExperiment} is
+      also returned.
+
+      \code{rowData} are combined using \code{\link{combineRows}} for
+      \code{DataFrame} objects. It is not necessary for all input objects to
+      have the same fields in their \code{rowData}; missing fields are filled
+      with \code{NA}s for the corresponding rows in the returned object.
+
       \code{metadata} from all objects are combined into a \code{list}
       with no name checking.
     }


### PR DESCRIPTION
Migrates code from `SingleCellExperiment::unsplitAltExps` to a more general (R)SE `combineRows` method:

```r
library(SummarizedExperiment)

se <- SummarizedExperiment(list(counts=matrix(rpois(1000, 10), ncol=10)))
colData(se)$A <- 1
se2 <- SummarizedExperiment(list(counts=matrix(rpois(1000, 10), ncol=10), 
    normalized=matrix(rnorm(1000), ncol=10)))
colData(se2)$B <- 1
stuff <- combineRows(se, se2, use.names=FALSE)
assay(stuff, 2)
## <200 x 10> matrix of class DelayedMatrix and type "double":
##               [,1]        [,2]        [,3] ...         [,9]        [,10]
##   [1,]          NA          NA          NA   .           NA           NA
##   [2,]          NA          NA          NA   .           NA           NA
##   [3,]          NA          NA          NA   .           NA           NA
##   [4,]          NA          NA          NA   .           NA           NA
##   [5,]          NA          NA          NA   .           NA           NA
##    ...           .           .           .   .            .            .
## [196,] -0.17431950  0.56670523 -0.42967676   . -0.278277345  0.008709013
## [197,] -1.00690858  0.15686986 -0.43111398   . -0.018939282 -0.146037514
## [198,]  0.04412168 -0.31165661  0.49380451   .  0.733140413  0.489446773
## [199,]  0.04936705 -0.53610868 -0.06959693   . -1.231104609  0.433193859
## [200,] -0.30115482  1.59633837  0.60413306   . -0.097482887  0.100487640

colnames(se) <- LETTERS[1:10]
colnames(se2) <- LETTERS[3:12]
stuff2 <- combineRows(se, se2)
assay(stuff2)
## <200 x 12> matrix of class DelayedMatrix and type "integer":
##         A  B  C  D ...  I  J  K  L
##   [1,] 14  7 18  9   .  5  8 NA NA
##   [2,] 11 12  4 12   . 11  9 NA NA
##   [3,] 11  8 16  8   . 10  8 NA NA
##   [4,] 11  4 10 16   .  8 13 NA NA
##   [5,] 13 11 13 12   . 15 11 NA NA
##    ...  .  .  .  .   .  .  .  .  .
## [196,] NA NA  8 17   . 13  7  9  8
## [197,] NA NA  8 12   . 12  9 12  7
## [198,] NA NA 13  6   . 12  4  6  7
## [199,] NA NA 14 13   .  2  9 12  8
## [200,] NA NA 17 10   .  7 14 15 11
```

The magic sauce is the use of the `ConstantMatrix`, hopefully to be added by Bioconductor/DelayedArray#87. This allows us to fill in missing columns and assays with `NA`s in an extremely lightweight manner. 

Mostly works for RSE's as well, though the example below fails if `se` and `se2` is swapped - not sure why.

```r
se <- SummarizedExperiment(list(counts=matrix(rpois(1000, 10), ncol=10)), rowRanges=GRanges("chrA", IRanges(1, 1:100)))
se2 <- SummarizedExperiment(list(counts=matrix(rpois(1000, 10), ncol=10), normalized=matrix(rnorm(1000), ncol=10)), 
    rowRanges=GRangesList(rep(list(GRanges()), 100)))
stuff3 <- combineRows(se2, se, use.names=FALSE)
```

Thoughts:

- Need to finish up Bioconductor/DelayedArray#87.
- Need a `combineRows` method for DFs to handle painless merging of `rowData`.
- Surely there is a cleaner way of handling the `c`'ing of different types of `rowData` classes, i.e., GRLs vs GRs?