### PR TITLE
Preserve assay dimnames during replacement

### DIFF
--- a/R/SummarizedExperiment-class.R
+++ b/R/SummarizedExperiment-class.R
@@ -333,6 +333,24 @@ setMethod("assay", c("SummarizedExperiment", "character"),
     res
 })
 
+.SummarizedExperiment.assay.replace <-
+    function(x, i, withDimnames=TRUE, ..., value)
+{
+    if (!isTRUEorFALSE(withDimnames))
+        stop(wmsg("'withDimnames' must be TRUE or FALSE"))
+    if (withDimnames && !is.null(value) &&
+        !.assays_have_expected_dimnames(list(value), dimnames(x)))
+        stop(wmsg("please use 'assay(x, withDimnames=FALSE) <- value' ",
+                  "or 'assays(x, withDimnames=FALSE) <- value' when ",
+                  "the rownames or colnames of the supplied assay ",
+                  "are not identical to those of the receiving ",
+                  class(x), " object 'x'"))
+    assays <- assays(x, withDimnames=FALSE, ...)
+    assays[[i]] <- value
+    assays(x, withDimnames=FALSE, ...) <- assays
+    x
+}
+
 setGeneric("assay<-", signature=c("x", "i"),
     function(x, i, withDimnames=TRUE, ..., value) standardGeneric("assay<-"))
 
@@ -342,22 +360,19 @@ setReplaceMethod("assay", c("SummarizedExperiment", "missing"),
     if (0L == length(assays(x, withDimnames=FALSE)))
         stop("'assay(<", class(x), ">) <- value' ", "length(assays(<",
              class(x), ">)) is 0")
-    assays(x, withDimnames=withDimnames, ...)[[1]] <- value
-    x
+    .SummarizedExperiment.assay.replace(x, 1L, withDimnames, ..., value=value)
 })
 
 setReplaceMethod("assay", c("SummarizedExperiment", "numeric"),
     function(x, i, withDimnames=TRUE, ..., value)
 {
-    assays(x, withDimnames=withDimnames, ...)[[i]] <- value
-    x
+    .SummarizedExperiment.assay.replace(x, i, withDimnames, ..., value=value)
 })
 
 setReplaceMethod("assay", c("SummarizedExperiment", "character"),
     function(x, i, withDimnames=TRUE, ..., value)
 {
-    assays(x, withDimnames=withDimnames, ...)[[i]] <- value
-    x
+    .SummarizedExperiment.assay.replace(x, i, withDimnames, ..., value=value)
 })
 
 setGeneric("assayNames", function(x, ...) standardGeneric("assayNames"))

--- a/inst/unitTests/test_SummarizedExperiment-class.R
+++ b/inst/unitTests/test_SummarizedExperiment-class.R
@@ -273,6 +273,23 @@ test_SummarizedExperiment_setters <- function()
     checkIdentical(se0, se)
 }
 
+test_SummarizedExperiment_assay_setters_preserve_assay_dimnames <- function()
+{
+    for (foo in list(matrix(runif(200), ncol=10),
+                    DelayedArray::DelayedArray(matrix(runif(200), ncol=10)))) {
+        se <- SummarizedExperiment(list(foo=foo))
+        rownames(se) <- letters[1:20]
+        colnames(se) <- LETTERS[1:10]
+        another <- matrix(runif(200), ncol=10, dimnames=dimnames(se))
+
+        assay(se, "bar") <- another
+        checkIdentical(NULL, dimnames(assay(se, "foo", withDimnames=FALSE)))
+
+        assay(se, "bar") <- NULL
+        checkIdentical(NULL, dimnames(assay(se, "foo", withDimnames=FALSE)))
+    }
+}
+
 test_SummarizedExperiment_subset <- function()
 {
     for (i in seq_along(se0List)) {


### PR DESCRIPTION
## Summary

Preserve the stored assays' own dimnames when adding, replacing, or removing an assay.

## Thanks to maintainers

Thanks to the Bioconductor maintainers for reviewing this edge case in the assay replacement API.

## Issue or motivation

This addresses #96. Adding an assay to an object whose top-level dimnames are set should not rewrite the dimnames of assays that were already stored without dimnames.

## Root cause

The assay replacement methods retrieved the full assay list through the default getter. That getter applies the top-level dimnames to each assay, and the setter then wrote those modified assays back to the object.

## Change

The replacement path now reads and writes the assay list with `withDimnames=FALSE`, while retaining validation for supplied assays when `withDimnames=TRUE`. The three assay replacement methods share this logic.

A regression test covers both ordinary matrices and `DelayedArray` assays, including adding and removing an assay.

## Tests

- Focused matrix and `DelayedArray` regression: passed.
- RUnit suite: 47 test functions, 0 errors, 0 failures.
- `R CMD build`: passed.
- `R CMD check --as-cran --no-manual`: 0 errors; the remaining 2 warnings and 3 notes concern existing vignette packaging and repository metadata.

## Scope

This does not change assay getter behavior, the explicit dimnames validation rule, or setter behavior for other object classes.
